### PR TITLE
fix: remove trailing whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,5 @@
     <title>Document</title>
 </head>
 <body>
-    
 </body>
 </html>


### PR DESCRIPTION
remove trailing whitespace in .html file to remove error